### PR TITLE
fix/pass vectors by reference

### DIFF
--- a/src/seed_search.cpp
+++ b/src/seed_search.cpp
@@ -98,7 +98,7 @@ void SeedSearch::GetSeqIdAndStart(vector<int> &db_seq_length, vector<int> &db_se
   return;
 }
 
-double SeedSearch::CalcAccessibility(vector<float> accessibility, vector<float> conditional_accessibility, int sp, int length){
+double SeedSearch::CalcAccessibility(vector<float> &accessibility, vector<float> &conditional_accessibility, int sp, int length){
   double temp = accessibility[sp];
   for(int i =_min_accessible_length; i < length; i++){
     temp += conditional_accessibility[sp+i];

--- a/src/seed_search.h
+++ b/src/seed_search.h
@@ -51,7 +51,7 @@ class SeedSearch {
   void GetSeqIdAndStart(vector<int> &db_seq_length, vector<int> &db_seq_start_position, int* seq_id, int* start, int sp, int length);
   void SeedSearchCore(vector<unsigned char> &query_seq, vector<int> &query_suffix_array, vector<unsigned char> &db_seq, vector<int> &db_suffix_array,  vector<vector<int> > &_start_hash,  vector<vector<int> > &_end_hash,vector<int> &db_seed, vector<int> &q_seed, int sp_q, int ep_q, int sp_db, int ep_db, double score, int length);
   void SeedSearchNextCharacter(vector<unsigned char> &encoded_sequences, vector<int> &suffix_array, int* start, int* end, unsigned char c, int offset);
-  double CalcAccessibility(vector<float> accessibility, vector<float> conditional_accessibility, int sp, int length);
+  double CalcAccessibility(vector<float> &accessibility, vector<float> &conditional_accessibility, int sp, int length);
 };
 
 #endif


### PR DESCRIPTION
**Description:**
Pass vectors by reference to avoid unnecessary copies. The function is run in a computation heavy loop, and so this changes proves to speedup the analyses remarkably.

**Benchmarking:**
| Dataset     | By value | By reference |
|-------------|----------|--------------|
| Lepidothrix |  564.31s |      537.49s |

**Configuration:**
- \#Processes: 2
- \#Threads per process: 8
- Algorithm: `block`
- NUMA architecture
- GCC v8.3.0
- OpenMPI v3.1.4

**Closes:** #4 